### PR TITLE
ignoring unnecessarily generated surefire report

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,4 +22,4 @@ jobs:
         java-version: '11'
         distribution: 'adopt'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --file pom.xml -DdisableXmlReport=true


### PR DESCRIPTION
In our analysis, we observe that this target/surefire-report/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime.
The generation of this directory can be disabled by simply adding -DdisableXmlReport=true to the mvn command.